### PR TITLE
fix: 포켓몬 에셋 변경

### DIFF
--- a/app/my-tree/page.tsx
+++ b/app/my-tree/page.tsx
@@ -59,7 +59,7 @@ export default function MyTreePage() {
   const router = useRouter();
   const searchParams = useSearchParams();
   const { translate, language } = useTranslation();
-  const publicId = searchParams.get('publicId');
+  const publicId = searchParams.get('publicId')||"1";
 
   // API 상태
   const [treeData, setTreeData] = useState<UserTreeData | null>(null);
@@ -202,7 +202,7 @@ export default function MyTreePage() {
       {/* ~님의 포케트리 텍스트, 공유하기 버튼 */}
       <div className="px-4 py-3 shrink-0 bg-primary-red flex items-center justify-between gap-2">
         <span className="text-white text-xl font-bold whitespace-nowrap">{userName}{translate("tree.userTree")}</span>
-        <button 
+        <button
           onClick={() => handleShareLinkClick()}
           className="relative w-36 h-10 flex items-center justify-center shrink-0"
         >

--- a/app/my-tree/page.tsx
+++ b/app/my-tree/page.tsx
@@ -59,7 +59,7 @@ export default function MyTreePage() {
   const router = useRouter();
   const searchParams = useSearchParams();
   const { translate, language } = useTranslation();
-  const publicId = searchParams.get('publicId')||"1";
+  const publicId = searchParams.get('publicId');
 
   // API 상태
   const [treeData, setTreeData] = useState<UserTreeData | null>(null);

--- a/features/landing/components/LandingTree/LandingTree.tsx
+++ b/features/landing/components/LandingTree/LandingTree.tsx
@@ -14,8 +14,8 @@ import { ALL_POKEMON_IMAGES } from "@/features/shared/data/pokemonData";
  * - 획득한 포켓몬을 트리 옆에 표시
  */
 
-// 랜딩 페이지에 표시할 포켓몬 인덱스 (실제 도감번호에서 -1로, 원하는 포켓몬 번호 선택)
-const DISPLAYED_POKEMON_INDICES = [6, 78, 53, 24, 131, 132, 3];
+// 랜딩 페이지에 표시할 포켓몬 인덱스 (0-80 범위, 원하는 포켓몬 번호 선택)
+const DISPLAYED_POKEMON_INDICES = [2, 32, 22, 9, 1, 67, 66];
 
 export function LandingTree() {
   // 선택된 포켓몬 이미지
@@ -91,9 +91,9 @@ export function LandingTree() {
       {displayedPokemons.map((pokemon, index) => {
         // 7마리 포켓몬 위치
         const pokemonPositions = [
-          { bottom: "70%", left: "10%", scaleX: -1 },  // 왼쪽 상단
-          { bottom: "52%", left: "1%", scaleX: -1 },  // 왼쪽 중단
-          { bottom: "20%", left: "2%", scaleX: -1 },  // 왼쪽 하단
+          { bottom: "70%", left: "10%", scaleX: 1 },  // 왼쪽 상단
+          { bottom: "52%", left: "1%", scaleX: 1 },  // 왼쪽 중단
+          { bottom: "20%", left: "2%", scaleX: 1 },  // 왼쪽 하단
           { bottom: "60%", right: "0%", scaleX: 1 },  // 오른쪽 상단
           { bottom: "25%", left: "80%", scaleX: 1 },  // 오른쪽 중상단
           { bottom: "8%", right: "45%", scaleX: 1 },  // 오른쪽 중하단

--- a/features/shared/data/pokemonData.ts
+++ b/features/shared/data/pokemonData.ts
@@ -1,157 +1,96 @@
 import { StaticImageData } from "next/image";
 
-// 포켓몬 이미지 동적 import
+// 포켓몬 base 이미지 import
+import Pokemon1 from "@/assets/images/pokemon/base/1-pokemon.png";
+import Pokemon2 from "@/assets/images/pokemon/base/2-pokemon.png";
+import Pokemon3 from "@/assets/images/pokemon/base/3-pokemon.png";
+import Pokemon4 from "@/assets/images/pokemon/base/4-pokemon.png";
+import Pokemon5 from "@/assets/images/pokemon/base/5-pokemon.png";
+import Pokemon6 from "@/assets/images/pokemon/base/6-pokemon.png";
+import Pokemon7 from "@/assets/images/pokemon/base/7-pokemon.png";
+import Pokemon8 from "@/assets/images/pokemon/base/8-pokemon.png";
+import Pokemon9 from "@/assets/images/pokemon/base/9-pokemon.png";
+import Pokemon10 from "@/assets/images/pokemon/base/10-pokemon.png";
+import Pokemon11 from "@/assets/images/pokemon/base/11-pokemon.png";
+import Pokemon12 from "@/assets/images/pokemon/base/12-pokemon.png";
+import Pokemon13 from "@/assets/images/pokemon/base/13-pokemon.png";
+import Pokemon14 from "@/assets/images/pokemon/base/14-pokemon.png";
+import Pokemon15 from "@/assets/images/pokemon/base/15-pokemon.png";
+import Pokemon16 from "@/assets/images/pokemon/base/16-pokemon.png";
+import Pokemon17 from "@/assets/images/pokemon/base/17-pokemon.png";
+import Pokemon18 from "@/assets/images/pokemon/base/18-pokemon.png";
+import Pokemon19 from "@/assets/images/pokemon/base/19-pokemon.png";
+import Pokemon20 from "@/assets/images/pokemon/base/20-pokemon.png";
+import Pokemon21 from "@/assets/images/pokemon/base/21-pokemon.png";
+import Pokemon22 from "@/assets/images/pokemon/base/22-pokemon.png";
+import Pokemon23 from "@/assets/images/pokemon/base/23-pokemon.png";
+import Pokemon24 from "@/assets/images/pokemon/base/24-pokemon.png";
+import Pokemon25 from "@/assets/images/pokemon/base/25-pokemon.png";
+import Pokemon26 from "@/assets/images/pokemon/base/26-pokemon.png";
+import Pokemon27 from "@/assets/images/pokemon/base/27-pokemon.png";
+import Pokemon28 from "@/assets/images/pokemon/base/28-pokemon.png";
+import Pokemon29 from "@/assets/images/pokemon/base/29-pokemon.png";
+import Pokemon30 from "@/assets/images/pokemon/base/30-pokemon.png";
+import Pokemon31 from "@/assets/images/pokemon/base/31-pokemon.png";
+import Pokemon32 from "@/assets/images/pokemon/base/32-pokemon.png";
+import Pokemon33 from "@/assets/images/pokemon/base/33-pokemon.png";
+import Pokemon34 from "@/assets/images/pokemon/base/34-pokemon.png";
+import Pokemon35 from "@/assets/images/pokemon/base/35-pokemon.png";
+import Pokemon36 from "@/assets/images/pokemon/base/36-pokemon.png";
+import Pokemon37 from "@/assets/images/pokemon/base/37-pokemon.png";
+import Pokemon38 from "@/assets/images/pokemon/base/38-pokemon.png";
+import Pokemon39 from "@/assets/images/pokemon/base/39-pokemon.png";
+import Pokemon40 from "@/assets/images/pokemon/base/40-pokemon.png";
+import Pokemon41 from "@/assets/images/pokemon/base/41-pokemon.png";
+import Pokemon42 from "@/assets/images/pokemon/base/42-pokemon.png";
+import Pokemon43 from "@/assets/images/pokemon/base/43-pokemon.png";
+import Pokemon44 from "@/assets/images/pokemon/base/44-pokemon.png";
+import Pokemon45 from "@/assets/images/pokemon/base/45-pokemon.png";
+import Pokemon46 from "@/assets/images/pokemon/base/46-pokemon.png";
+import Pokemon47 from "@/assets/images/pokemon/base/47-pokemon.png";
+import Pokemon48 from "@/assets/images/pokemon/base/48-pokemon.png";
+import Pokemon49 from "@/assets/images/pokemon/base/49-pokemon.png";
+import Pokemon50 from "@/assets/images/pokemon/base/50-pokemon.png";
+import Pokemon51 from "@/assets/images/pokemon/base/51-pokemon.png";
+import Pokemon52 from "@/assets/images/pokemon/base/52-pokemon.png";
+import Pokemon53 from "@/assets/images/pokemon/base/53-pokemon.png";
+import Pokemon54 from "@/assets/images/pokemon/base/54-pokemon.png";
+import Pokemon55 from "@/assets/images/pokemon/base/55-pokemon.png";
+import Pokemon56 from "@/assets/images/pokemon/base/56-pokemon.png";
+import Pokemon57 from "@/assets/images/pokemon/base/57-pokemon.png";
+import Pokemon58 from "@/assets/images/pokemon/base/58-pokemon.png";
+import Pokemon59 from "@/assets/images/pokemon/base/59-pokemon.png";
+import Pokemon60 from "@/assets/images/pokemon/base/60-pokemon.png";
+import Pokemon61 from "@/assets/images/pokemon/base/61-pokemon.png";
+import Pokemon62 from "@/assets/images/pokemon/base/62-pokemon.png";
+import Pokemon63 from "@/assets/images/pokemon/base/63-pokemon.png";
+import Pokemon64 from "@/assets/images/pokemon/base/64-pokemon.png";
+import Pokemon65 from "@/assets/images/pokemon/base/65-pokemon.png";
+import Pokemon66 from "@/assets/images/pokemon/base/66-pokemon.png";
+import Pokemon67 from "@/assets/images/pokemon/base/67-pokemon.png";
+import Pokemon68 from "@/assets/images/pokemon/base/68-pokemon.png";
+import Pokemon69 from "@/assets/images/pokemon/base/69-pokemon.png";
+import Pokemon70 from "@/assets/images/pokemon/base/70-pokemon.png";
+import Pokemon71 from "@/assets/images/pokemon/base/71-pokemon.png";
+import Pokemon72 from "@/assets/images/pokemon/base/72-pokemon.png";
+import Pokemon73 from "@/assets/images/pokemon/base/73-pokemon.png";
+import Pokemon74 from "@/assets/images/pokemon/base/74-pokemon.png";
+import Pokemon75 from "@/assets/images/pokemon/base/75-pokemon.png";
+import Pokemon76 from "@/assets/images/pokemon/base/76-pokemon.png";
+import Pokemon77 from "@/assets/images/pokemon/base/77-pokemon.png";
+import Pokemon78 from "@/assets/images/pokemon/base/78-pokemon.png";
+import Pokemon79 from "@/assets/images/pokemon/base/79-pokemon.png";
+import Pokemon80 from "@/assets/images/pokemon/base/80-pokemon.png";
+import Pokemon81 from "@/assets/images/pokemon/base/81-pokemon.png";
+
+/*
+// 포켓몬 webp이미지 동적 import (주석처리)
 import Pokemon1 from "@/assets/images/pokemonWebp/pokemon/pokemon1.webp";
 import Pokemon2 from "@/assets/images/pokemonWebp/pokemon/pokemon2.webp";
 import Pokemon3 from "@/assets/images/pokemonWebp/pokemon/pokemon3.webp";
-import Pokemon4 from "@/assets/images/pokemonWebp/pokemon/pokemon4.webp";
-import Pokemon5 from "@/assets/images/pokemonWebp/pokemon/pokemon5.webp";
-import Pokemon6 from "@/assets/images/pokemonWebp/pokemon/pokemon6.webp";
-import Pokemon7 from "@/assets/images/pokemonWebp/pokemon/pokemon7.webp";
-import Pokemon8 from "@/assets/images/pokemonWebp/pokemon/pokemon8.webp";
-import Pokemon9 from "@/assets/images/pokemonWebp/pokemon/pokemon9.webp";
-import Pokemon10 from "@/assets/images/pokemonWebp/pokemon/pokemon10.webp";
-import Pokemon11 from "@/assets/images/pokemonWebp/pokemon/pokemon11.webp";
-import Pokemon12 from "@/assets/images/pokemonWebp/pokemon/pokemon12.webp";
-import Pokemon13 from "@/assets/images/pokemonWebp/pokemon/pokemon13.webp";
-import Pokemon14 from "@/assets/images/pokemonWebp/pokemon/pokemon14.webp";
-import Pokemon15 from "@/assets/images/pokemonWebp/pokemon/pokemon15.webp";
-import Pokemon16 from "@/assets/images/pokemonWebp/pokemon/pokemon16.webp";
-import Pokemon17 from "@/assets/images/pokemonWebp/pokemon/pokemon17.webp";
-import Pokemon18 from "@/assets/images/pokemonWebp/pokemon/pokemon18.webp";
-import Pokemon19 from "@/assets/images/pokemonWebp/pokemon/pokemon19.webp";
-import Pokemon20 from "@/assets/images/pokemonWebp/pokemon/pokemon20.webp";
-import Pokemon21 from "@/assets/images/pokemonWebp/pokemon/pokemon21.webp";
-import Pokemon22 from "@/assets/images/pokemonWebp/pokemon/pokemon22.webp";
-import Pokemon23 from "@/assets/images/pokemonWebp/pokemon/pokemon23.webp";
-import Pokemon24 from "@/assets/images/pokemonWebp/pokemon/pokemon24.webp";
-import Pokemon25 from "@/assets/images/pokemonWebp/pokemon/pokemon25.webp";
-import Pokemon26 from "@/assets/images/pokemonWebp/pokemon/pokemon26.webp";
-import Pokemon27 from "@/assets/images/pokemonWebp/pokemon/pokemon27.webp";
-import Pokemon28 from "@/assets/images/pokemonWebp/pokemon/pokemon28.webp";
-import Pokemon29 from "@/assets/images/pokemonWebp/pokemon/pokemon29.webp";
-import Pokemon30 from "@/assets/images/pokemonWebp/pokemon/pokemon30.webp";
-import Pokemon31 from "@/assets/images/pokemonWebp/pokemon/pokemon31.webp";
-import Pokemon32 from "@/assets/images/pokemonWebp/pokemon/pokemon32.webp";
-import Pokemon33 from "@/assets/images/pokemonWebp/pokemon/pokemon33.webp";
-import Pokemon34 from "@/assets/images/pokemonWebp/pokemon/pokemon34.webp";
-import Pokemon35 from "@/assets/images/pokemonWebp/pokemon/pokemon35.webp";
-import Pokemon36 from "@/assets/images/pokemonWebp/pokemon/pokemon36.webp";
-import Pokemon37 from "@/assets/images/pokemonWebp/pokemon/pokemon37.webp";
-import Pokemon38 from "@/assets/images/pokemonWebp/pokemon/pokemon38.webp";
-import Pokemon39 from "@/assets/images/pokemonWebp/pokemon/pokemon39.webp";
-import Pokemon40 from "@/assets/images/pokemonWebp/pokemon/pokemon40.webp";
-import Pokemon41 from "@/assets/images/pokemonWebp/pokemon/pokemon41.webp";
-import Pokemon42 from "@/assets/images/pokemonWebp/pokemon/pokemon42.webp";
-import Pokemon43 from "@/assets/images/pokemonWebp/pokemon/pokemon43.webp";
-import Pokemon44 from "@/assets/images/pokemonWebp/pokemon/pokemon44.webp";
-import Pokemon45 from "@/assets/images/pokemonWebp/pokemon/pokemon45.webp";
-import Pokemon46 from "@/assets/images/pokemonWebp/pokemon/pokemon46.webp";
-import Pokemon47 from "@/assets/images/pokemonWebp/pokemon/pokemon47.webp";
-import Pokemon48 from "@/assets/images/pokemonWebp/pokemon/pokemon48.webp";
-import Pokemon49 from "@/assets/images/pokemonWebp/pokemon/pokemon49.webp";
-import Pokemon50 from "@/assets/images/pokemonWebp/pokemon/pokemon50.webp";
-import Pokemon51 from "@/assets/images/pokemonWebp/pokemon/pokemon51.webp";
-import Pokemon52 from "@/assets/images/pokemonWebp/pokemon/pokemon52.webp";
-import Pokemon53 from "@/assets/images/pokemonWebp/pokemon/pokemon53.webp";
-import Pokemon54 from "@/assets/images/pokemonWebp/pokemon/pokemon54.webp";
-import Pokemon55 from "@/assets/images/pokemonWebp/pokemon/pokemon55.webp";
-import Pokemon56 from "@/assets/images/pokemonWebp/pokemon/pokemon56.webp";
-import Pokemon57 from "@/assets/images/pokemonWebp/pokemon/pokemon57.webp";
-import Pokemon58 from "@/assets/images/pokemonWebp/pokemon/pokemon58.webp";
-import Pokemon59 from "@/assets/images/pokemonWebp/pokemon/pokemon59.webp";
-import Pokemon60 from "@/assets/images/pokemonWebp/pokemon/pokemon60.webp";
-import Pokemon61 from "@/assets/images/pokemonWebp/pokemon/pokemon61.webp";
-import Pokemon62 from "@/assets/images/pokemonWebp/pokemon/pokemon62.webp";
-import Pokemon63 from "@/assets/images/pokemonWebp/pokemon/pokemon63.webp";
-import Pokemon64 from "@/assets/images/pokemonWebp/pokemon/pokemon64.webp";
-import Pokemon65 from "@/assets/images/pokemonWebp/pokemon/pokemon65.webp";
-import Pokemon66 from "@/assets/images/pokemonWebp/pokemon/pokemon66.webp";
-import Pokemon67 from "@/assets/images/pokemonWebp/pokemon/pokemon67.webp";
-import Pokemon68 from "@/assets/images/pokemonWebp/pokemon/pokemon68.webp";
-import Pokemon69 from "@/assets/images/pokemonWebp/pokemon/pokemon69.webp";
-import Pokemon70 from "@/assets/images/pokemonWebp/pokemon/pokemon70.webp";
-import Pokemon71 from "@/assets/images/pokemonWebp/pokemon/pokemon71.webp";
-import Pokemon72 from "@/assets/images/pokemonWebp/pokemon/pokemon72.webp";
-import Pokemon73 from "@/assets/images/pokemonWebp/pokemon/pokemon73.webp";
-import Pokemon74 from "@/assets/images/pokemonWebp/pokemon/pokemon74.webp";
-import Pokemon75 from "@/assets/images/pokemonWebp/pokemon/pokemon75.webp";
-import Pokemon76 from "@/assets/images/pokemonWebp/pokemon/pokemon76.webp";
-import Pokemon77 from "@/assets/images/pokemonWebp/pokemon/pokemon77.webp";
-import Pokemon78 from "@/assets/images/pokemonWebp/pokemon/pokemon78.webp";
-import Pokemon79 from "@/assets/images/pokemonWebp/pokemon/pokemon79.webp";
-import Pokemon80 from "@/assets/images/pokemonWebp/pokemon/pokemon80.webp";
-import Pokemon81 from "@/assets/images/pokemonWebp/pokemon/pokemon81.webp";
-import Pokemon82 from "@/assets/images/pokemonWebp/pokemon/pokemon82.webp";
-import Pokemon83 from "@/assets/images/pokemonWebp/pokemon/pokemon83.webp";
-import Pokemon84 from "@/assets/images/pokemonWebp/pokemon/pokemon84.webp";
-import Pokemon85 from "@/assets/images/pokemonWebp/pokemon/pokemon85.webp";
-import Pokemon86 from "@/assets/images/pokemonWebp/pokemon/pokemon86.webp";
-import Pokemon87 from "@/assets/images/pokemonWebp/pokemon/pokemon87.webp";
-import Pokemon88 from "@/assets/images/pokemonWebp/pokemon/pokemon88.webp";
-import Pokemon89 from "@/assets/images/pokemonWebp/pokemon/pokemon89.webp";
-import Pokemon90 from "@/assets/images/pokemonWebp/pokemon/pokemon90.webp";
-import Pokemon91 from "@/assets/images/pokemonWebp/pokemon/pokemon91.webp";
-import Pokemon92 from "@/assets/images/pokemonWebp/pokemon/pokemon92.webp";
-import Pokemon93 from "@/assets/images/pokemonWebp/pokemon/pokemon93.webp";
-import Pokemon94 from "@/assets/images/pokemonWebp/pokemon/pokemon94.webp";
-import Pokemon95 from "@/assets/images/pokemonWebp/pokemon/pokemon95.webp";
-import Pokemon96 from "@/assets/images/pokemonWebp/pokemon/pokemon96.webp";
-import Pokemon97 from "@/assets/images/pokemonWebp/pokemon/pokemon97.webp";
-import Pokemon98 from "@/assets/images/pokemonWebp/pokemon/pokemon98.webp";
-import Pokemon99 from "@/assets/images/pokemonWebp/pokemon/pokemon99.webp";
-import Pokemon100 from "@/assets/images/pokemonWebp/pokemon/pokemon100.webp";
-import Pokemon101 from "@/assets/images/pokemonWebp/pokemon/pokemon101.webp";
-import Pokemon102 from "@/assets/images/pokemonWebp/pokemon/pokemon102.webp";
-import Pokemon103 from "@/assets/images/pokemonWebp/pokemon/pokemon103.webp";
-import Pokemon104 from "@/assets/images/pokemonWebp/pokemon/pokemon104.webp";
-import Pokemon105 from "@/assets/images/pokemonWebp/pokemon/pokemon105.webp";
-import Pokemon106 from "@/assets/images/pokemonWebp/pokemon/pokemon106.webp";
-import Pokemon107 from "@/assets/images/pokemonWebp/pokemon/pokemon107.webp";
-import Pokemon108 from "@/assets/images/pokemonWebp/pokemon/pokemon108.webp";
-import Pokemon109 from "@/assets/images/pokemonWebp/pokemon/pokemon109.webp";
-import Pokemon110 from "@/assets/images/pokemonWebp/pokemon/pokemon110.webp";
-import Pokemon111 from "@/assets/images/pokemonWebp/pokemon/pokemon111.webp";
-import Pokemon112 from "@/assets/images/pokemonWebp/pokemon/pokemon112.webp";
-import Pokemon113 from "@/assets/images/pokemonWebp/pokemon/pokemon113.webp";
-import Pokemon114 from "@/assets/images/pokemonWebp/pokemon/pokemon114.webp";
-import Pokemon115 from "@/assets/images/pokemonWebp/pokemon/pokemon115.webp";
-import Pokemon116 from "@/assets/images/pokemonWebp/pokemon/pokemon116.webp";
-import Pokemon117 from "@/assets/images/pokemonWebp/pokemon/pokemon117.webp";
-import Pokemon118 from "@/assets/images/pokemonWebp/pokemon/pokemon118.webp";
-import Pokemon119 from "@/assets/images/pokemonWebp/pokemon/pokemon119.webp";
-import Pokemon120 from "@/assets/images/pokemonWebp/pokemon/pokemon120.webp";
-import Pokemon121 from "@/assets/images/pokemonWebp/pokemon/pokemon121.webp";
-import Pokemon122 from "@/assets/images/pokemonWebp/pokemon/pokemon122.webp";
-import Pokemon123 from "@/assets/images/pokemonWebp/pokemon/pokemon123.webp";
-import Pokemon124 from "@/assets/images/pokemonWebp/pokemon/pokemon124.webp";
-import Pokemon125 from "@/assets/images/pokemonWebp/pokemon/pokemon125.webp";
-import Pokemon126 from "@/assets/images/pokemonWebp/pokemon/pokemon126.webp";
-import Pokemon127 from "@/assets/images/pokemonWebp/pokemon/pokemon127.webp";
-import Pokemon128 from "@/assets/images/pokemonWebp/pokemon/pokemon128.webp";
-import Pokemon129 from "@/assets/images/pokemonWebp/pokemon/pokemon129.webp";
-import Pokemon130 from "@/assets/images/pokemonWebp/pokemon/pokemon130.webp";
-import Pokemon131 from "@/assets/images/pokemonWebp/pokemon/pokemon131.webp";
-import Pokemon132 from "@/assets/images/pokemonWebp/pokemon/pokemon132.webp";
-import Pokemon133 from "@/assets/images/pokemonWebp/pokemon/pokemon133.webp";
-import Pokemon134 from "@/assets/images/pokemonWebp/pokemon/pokemon134.webp";
-import Pokemon135 from "@/assets/images/pokemonWebp/pokemon/pokemon135.webp";
-import Pokemon136 from "@/assets/images/pokemonWebp/pokemon/pokemon136.webp";
-import Pokemon137 from "@/assets/images/pokemonWebp/pokemon/pokemon137.webp";
-import Pokemon138 from "@/assets/images/pokemonWebp/pokemon/pokemon138.webp";
-import Pokemon139 from "@/assets/images/pokemonWebp/pokemon/pokemon139.webp";
-import Pokemon140 from "@/assets/images/pokemonWebp/pokemon/pokemon140.webp";
-import Pokemon141 from "@/assets/images/pokemonWebp/pokemon/pokemon141.webp";
-import Pokemon142 from "@/assets/images/pokemonWebp/pokemon/pokemon142.webp";
-import Pokemon143 from "@/assets/images/pokemonWebp/pokemon/pokemon143.webp";
-import Pokemon144 from "@/assets/images/pokemonWebp/pokemon/pokemon144.webp";
-import Pokemon145 from "@/assets/images/pokemonWebp/pokemon/pokemon145.webp";
-import Pokemon146 from "@/assets/images/pokemonWebp/pokemon/pokemon146.webp";
-import Pokemon147 from "@/assets/images/pokemonWebp/pokemon/pokemon147.webp";
-import Pokemon148 from "@/assets/images/pokemonWebp/pokemon/pokemon148.webp";
-import Pokemon149 from "@/assets/images/pokemonWebp/pokemon/pokemon149.webp";
-import Pokemon150 from "@/assets/images/pokemonWebp/pokemon/pokemon150.webp";
+... (생략)
 import Pokemon151 from "@/assets/images/pokemonWebp/pokemon/pokemon151.webp";
+*/
 
 /**
  * 전체 포켓몬 이미지 배열 (인덱스 0 = 포켓몬 1번)
@@ -165,24 +104,17 @@ export const ALL_POKEMON_IMAGES: StaticImageData[] = [
   Pokemon51, Pokemon52, Pokemon53, Pokemon54, Pokemon55, Pokemon56, Pokemon57, Pokemon58, Pokemon59, Pokemon60,
   Pokemon61, Pokemon62, Pokemon63, Pokemon64, Pokemon65, Pokemon66, Pokemon67, Pokemon68, Pokemon69, Pokemon70,
   Pokemon71, Pokemon72, Pokemon73, Pokemon74, Pokemon75, Pokemon76, Pokemon77, Pokemon78, Pokemon79, Pokemon80,
-  Pokemon81, Pokemon82, Pokemon83, Pokemon84, Pokemon85, Pokemon86, Pokemon87, Pokemon88, Pokemon89, Pokemon90,
-  Pokemon91, Pokemon92, Pokemon93, Pokemon94, Pokemon95, Pokemon96, Pokemon97, Pokemon98, Pokemon99, Pokemon100,
-  Pokemon101, Pokemon102, Pokemon103, Pokemon104, Pokemon105, Pokemon106, Pokemon107, Pokemon108, Pokemon109, Pokemon110,
-  Pokemon111, Pokemon112, Pokemon113, Pokemon114, Pokemon115, Pokemon116, Pokemon117, Pokemon118, Pokemon119, Pokemon120,
-  Pokemon121, Pokemon122, Pokemon123, Pokemon124, Pokemon125, Pokemon126, Pokemon127, Pokemon128, Pokemon129, Pokemon130,
-  Pokemon131, Pokemon132, Pokemon133, Pokemon134, Pokemon135, Pokemon136, Pokemon137, Pokemon138, Pokemon139, Pokemon140,
-  Pokemon141, Pokemon142, Pokemon143, Pokemon144, Pokemon145, Pokemon146, Pokemon147, Pokemon148, Pokemon149, Pokemon150,
-  Pokemon151,
+  Pokemon81,
 ];
 
 /**
  * 포켓몬 인덱스로 이미지 가져오기
- * @param index 포켓몬 번호 (1~151)
+ * @param index 포켓몬 번호 (1~81)
  * @returns 해당 포켓몬 이미지
  */
 export function getPokemonImage(index: number): StaticImageData {
-  // 인덱스 범위 검증 (1~151)
-  const validIndex = Math.max(1, Math.min(151, index));
+  // 인덱스 범위 검증 (1~81)
+  const validIndex = Math.max(1, Math.min(81, index));
   return ALL_POKEMON_IMAGES[validIndex - 1];
 }
 
@@ -199,10 +131,10 @@ export function getRandomPokemonImages(count: number): StaticImageData[] {
 /**
  * 랜덤하게 n개의 포켓몬 인덱스 선택
  * @param count 선택할 포켓몬 수
- * @returns 랜덤 포켓몬 인덱스 배열 (1~151)
+ * @returns 랜덤 포켓몬 인덱스 배열 (1~81)
  */
 export function getRandomPokemonIndices(count: number): number[] {
-  const indices = Array.from({ length: 151 }, (_, i) => i + 1);
+  const indices = Array.from({ length: 81 }, (_, i) => i + 1);
   const shuffled = indices.sort(() => Math.random() - 0.5);
   return shuffled.slice(0, count);
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **버그 수정**
  * 누락된 공개 ID 매개변수가 기본값으로 설정되어 오류 경로를 우회하도록 개선했습니다.

* **업데이트**
  * 랜딩 페이지에 표시되는 포켓몬 선택이 갱신되었습니다.
  * 일부 포켓몬의 시각적 좌우 방향이 조정되었습니다.
  * 포켓몬 이미지와 관련 데이터가 처음 81종으로 제한되었습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->