### PR TITLE
feat: 남의 트리 방문할때 메세지 작성하기 및 내 포케트리 만들러 가기 컴포넌트 (묶어서)

### DIFF
--- a/app/my-tree/page.tsx
+++ b/app/my-tree/page.tsx
@@ -7,6 +7,7 @@ import { Tree } from "@/features/my-tree/components/Tree";
 import { BottomButtons } from "@/features/shared/components/BottomButtons/BottomButtons";
 import { SocialMediaButton } from "@/features/shared/components/SocialMediaButton/SocialMediaButton";
 import LetterModal from "@/features/shared/components/Modal/LetterModal";
+import { VisitorButtons } from "@/features/shared/components/VisitorButtons/VisitorButtons";
 import { ShareLinkModal } from "@/features/shared/components/Modal/ShareLinkModal";
 import { useTranslation } from "@/features/shared/utils/translate/useLanguage";
 import {
@@ -197,6 +198,10 @@ export default function MyTreePage() {
     setIsShareLinkModalOpen(true);
   }
 
+  const handleMakePokeTree = () => {
+    router.push("/signup-or-go");
+  };
+
   return (
     <div className="flex flex-col">
       {/* ~님의 포케트리 텍스트, 공유하기 버튼 */}
@@ -242,17 +247,11 @@ export default function MyTreePage() {
             onCheckMessage={handleViewAllMessages}
           />
         ) : (
-          /* TODO:아래의 BottomButtons 대신
-          이슈에 올라와있는 버튼두개를
-          하나로 묶은 컴포넌트를 추가하면 됩니다!*/
-          <BottomButtons
-            onUp={handleUp}
-            onDown={handleDown}
-            onLeft={handleLeft}
-            onRight={handleRight}
+          <VisitorButtons
             onSendMessage={() => {
               alert('포켓 메시지 보내기 (구현 예정)');
             }}
+            onMakeTree={handleMakePokeTree}
           />
         )}
       </div>

--- a/features/shared/components/VisitorButtons/VisitorButtons.tsx
+++ b/features/shared/components/VisitorButtons/VisitorButtons.tsx
@@ -1,0 +1,68 @@
+"use client";
+
+import Image from "next/image";
+import { useTranslation } from "@/features/shared/utils/translate/useLanguage";
+import ButtonBigGreen from "@/assets/images/components/button_big_green.png";
+import ButtonMediumSky from "@/assets/images/components/button_medium_skyblue.png";
+
+interface VisitorButtonsProps {
+  onSendMessage: () => void;
+  onMakeTree: () => void;
+}
+
+/*
+ *  방문자 버튼 그룹
+ *  - 메시지 작성하기 버튼
+ *  - 내 포케트리 만들러 가기 버튼
+ */
+export function VisitorButtons({
+  onSendMessage,
+  onMakeTree,
+}: VisitorButtonsProps) {
+  const { translate } = useTranslation();
+
+  return (
+    <div className="flex flex-col items-center gap-2 w-fill h-fill">
+      {/* 메시지 작성하기 버튼 (클릭시 메시지 작성으로 이동) */}
+      <div className="shrink-0 w-fill h-fill">
+        <button
+          className="relative w-[344px] h-[96px] mt-2"
+          onClick={() => onSendMessage()}
+        >
+          <Image
+            src={ButtonBigGreen}
+            alt={translate("visitor.makeMessage")}
+            fill
+            unoptimized
+            className="object-fill"
+          />
+          <span className="absolute inset-0 flex items-center justify-center">
+            <span className="font-bold text-[32px] text-black">
+              {translate("visitor.makeMessage")}
+            </span>
+          </span>
+        </button>
+      </div>
+      {/* 내 포케트리 만들러 가기 버튼 (클릭시 포케트리 만들기로 이동) */}
+      <div className="shrink-0 w-fill h-fill mt-6">
+        <button
+          className="relative w-[193px] h-[56px]"
+          onClick={() => onMakeTree()}
+        >
+          <Image
+            src={ButtonMediumSky}
+            alt={translate("visitor.makeTree")}
+            fill
+            unoptimized
+            className="object-fill"
+          />
+          <span className="absolute inset-0 flex items-center justify-center">
+            <span className="font-semibold text-[16px] text-black">
+              {translate("visitor.makeTree")}
+            </span>
+          </span>
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/features/shared/utils/translate/languages/en.ts
+++ b/features/shared/utils/translate/languages/en.ts
@@ -41,6 +41,10 @@ export const en = {
     level: "Level",
     experience: "EXP",
   },
+  visitor: {
+    makeMessage: "Write a message",
+    makeTree: "Create my PokéTree",
+  },
   message: {
     title: "Pockét Message",
     placeholder: "Enter message",

--- a/features/shared/utils/translate/languages/en.ts
+++ b/features/shared/utils/translate/languages/en.ts
@@ -42,7 +42,7 @@ export const en = {
     experience: "EXP",
   },
   visitor: {
-    makeMessage: "Write a message",
+    makeMessage: "Send a message",
     makeTree: "Create my PokéTree",
   },
   message: {

--- a/features/shared/utils/translate/languages/ja.ts
+++ b/features/shared/utils/translate/languages/ja.ts
@@ -41,6 +41,10 @@ export const ja = {
     level: "レベル",
     experience: "経験値",
   },
+  visitor: {
+    makeMessage: "メッセージをかく",
+    makeTree: "マイポケツリーをつくる",
+  },
   message: {
     title: "ポケットメッセージ",
     placeholder: "メッセージを入力",

--- a/features/shared/utils/translate/languages/ko.ts
+++ b/features/shared/utils/translate/languages/ko.ts
@@ -41,6 +41,10 @@ export const ko = {
     level: "레벨",
     experience: "경험치",
   },
+  visitor: {
+    makeMessage: "메시지 작성하기",
+    makeTree: "내 포케트리 만들러 가기",
+  },
   message: {
     title: "포켓 메시지",
     placeholder: "메시지를 입력하세요",


### PR DESCRIPTION
## 구현 내용
- 다른 포케트리에 방문한 유저에게 보여주는 메시지 작성하기, 내 포케트리 만들기 UI 구현
- 내 포케트리 만들기 클릭시 포케트리 만들기 화면으로 이동

## 변경 사항
- 내 포케트리가 아닌 다른사람의 포케트리를 보고 있는 경우 메시지 작성하기, 내 포케트리 만들러 가기 버튼 컴포넌트가 보여짐

## 특이사항
- 아직 메시지 작성하기 버튼은 비활성화 (메시지 작성 모달 구현중)
- 한자 폰트지원이 안되서 한자는 모두 히라가나로 작성

## 스크린샷
### 메시지 작성하기, 내 포케트리 만들러 가기 컴포넌트 (한국어, 일본어, 영어 순)

#### PC
<img width="440" height="663" alt="스크린샷 2025-11-29 오후 7 38 23" src="https://github.com/user-attachments/assets/92a5fe59-392f-427c-af9d-53064dfb9d2a" />

<img width="431" height="607" alt="스크린샷 2025-11-29 오후 7 38 44" src="https://github.com/user-attachments/assets/421def5a-acd6-4ff0-8da3-22e7de215d6e" />

<img width="415" height="628" alt="스크린샷 2025-11-29 오후 7 38 37" src="https://github.com/user-attachments/assets/ef2a0285-6e75-483a-b247-c2fb142f2475" />

#### 모바일 (갤럭시S22)


![poketree_korea](https://github.com/user-attachments/assets/2d8d1de8-ed08-4c61-99ee-c9b6c636076e)

![poketree_japan](https://github.com/user-attachments/assets/ba90a89d-35f8-4680-a6b4-556ac5872d06)

![poketree_english](https://github.com/user-attachments/assets/31101d22-cefe-478e-be4f-0713b7a03b7a)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 비소유자 사용자를 위한 방문자 버튼 추가 - 메시지 전송 및 포케트리 생성 옵션 제공
  * 다국어 지원 확대 - 방문자 기능에 대한 영어, 일본어, 한국어 번역 추가

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->