### PR TITLE
Feature/issue fix 1201

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -46,7 +46,7 @@ const pfStardust = localFont({
 });
 
 export const metadata: Metadata = {
-  title: "PokémTree",
+  title: "PokéTree",
   description: "Christmas Event with Pokémon",
   icons: {
     icon: "/icon.png",

--- a/app/my-pokedex/page.tsx
+++ b/app/my-pokedex/page.tsx
@@ -14,7 +14,7 @@ function MyPokedexPageContent() {
   const searchParams = useSearchParams();
   const publicId = searchParams.get('id');
 
-  const [selectedIndex, setSelectedIndex] = useState(() => {
+  const [selectedIndex] = useState(() => {
     if (typeof window !== 'undefined') {
       const savedIndex = localStorage.getItem("selectedIndex");
       if (savedIndex !== null) {
@@ -42,7 +42,7 @@ function MyPokedexPageContent() {
         const ownedCount = data.filter((p) => p.isOwned).length;
         const totalCount = data.length;
         setIsMaster(ownedCount === totalCount);
-      } catch (err) {
+      } catch {
         // 에러 발생 시 에러 페이지로 리다이렉트
         router.replace("/error?type=load");
       }

--- a/app/my-pokedex/page.tsx
+++ b/app/my-pokedex/page.tsx
@@ -4,8 +4,10 @@ import { Suspense } from "react";
 import { useState, useEffect } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import { PokedexGrid } from "@/features/my-pokedex/components/PokedexGrid";
-import { getMyPokedex, PokemonInDex } from "@/features/my-pokedex/usecases/getMyPokedex";
+import { getMyPokedex } from "@/features/my-pokedex/usecases/getMyPokedex";
 import { useTranslation } from "@/features/shared/utils/translate/useLanguage";
+import { isApiError } from "@/features/shared/utils/api/apiClient";
+import { POKEMON_DATA } from "@/features/shared/data/pokemonData";
 
 // 포켓몬 목록 페이지
 function MyPokedexPageContent() {
@@ -23,8 +25,9 @@ function MyPokedexPageContent() {
     }
     return 0;
   });
-  const [pokemons, setPokemons] = useState<PokemonInDex[]>([]);
+  const [ownedPokemonIds, setOwnedPokemonIds] = useState<number[]>([]);
   const [isMaster, setIsMaster] = useState(false);
+  const [userName, setUserName] = useState("");
 
   useEffect(() => {
     // publicId가 없으면 에러 페이지로 리다이렉트
@@ -35,28 +38,32 @@ function MyPokedexPageContent() {
 
     const fetchPokemons = async () => {
       try {
-        const data = await getMyPokedex({ publicId });
-        setPokemons(data);
+        const res = await getMyPokedex({ publicId });
+        const { pokemon_list, nickname, isMaster } = res.data;
 
-        // 마스터 여부 체크
-        const ownedCount = data.filter((p) => p.isOwned).length;
-        const totalCount = data.length;
-        setIsMaster(ownedCount === totalCount);
-      } catch {
-        // 에러 발생 시 에러 페이지로 리다이렉트
-        router.replace("/error?type=load");
+        setOwnedPokemonIds(pokemon_list ?? []);
+        setUserName(nickname);
+        // 문자열/불리언 모두 대응 (타입 단언으로 비교)
+        const isMasterStr = isMaster as unknown as string;
+        setIsMaster(isMasterStr === "true" || isMasterStr === "1");
+      } catch (err) {
+        // 에러 발생 시 에러 페이지로 리다이렉트 (에러 메시지 전달 시도)
+        if (isApiError(err) && err.message) {
+          router.replace(`/error?type=load&message=${encodeURIComponent(err.message)}`);
+        } else if (err instanceof Error && err.message) {
+          router.replace(`/error?type=load&message=${encodeURIComponent(err.message)}`);
+        } else {
+          router.replace("/error?type=load");
+        }
       }
     };
 
     fetchPokemons();
   }, [publicId, router]);
 
-  // 사용자 이름 (하드코딩)
-  const userName = "상화";
-
   // 획득한 포켓몬 수 계산
-  const ownedCount = pokemons.filter((p) => p.isOwned).length;
-  const totalCount = pokemons.length;
+  const ownedCount = ownedPokemonIds.length;
+  const totalCount = POKEMON_DATA.length;
 
   return (
     <div className="flex-1 flex flex-col bg-[#BF0120] overflow-hidden">
@@ -82,7 +89,7 @@ function MyPokedexPageContent() {
 
       {/* 그리드 영역 - 컨테이너 높이에서 헤더(110px)와 하단여백(10px)을 뺀 높이 */}
       <div className="h-[calc(100vh-120px)] md:h-[660px] overflow-hidden">
-        <PokedexGrid pokemons={pokemons} selectedIndex={selectedIndex} />
+        <PokedexGrid ownedPokemonIds={ownedPokemonIds} selectedIndex={selectedIndex} />
       </div>
 
       {/* 하단 여백 */}

--- a/app/my-poket-message/page.tsx
+++ b/app/my-poket-message/page.tsx
@@ -20,6 +20,7 @@ function MyPoketMessagePageContent() {
 
   const [messages, setMessages] = useState<Letter[]>([]);
   const [userName, setUserName] = useState("");
+  const [isOwner, setIsOwner] = useState("false");
   const [isLoading, setIsLoading] = useState(true);
 
   // 모달 관련 state
@@ -40,8 +41,9 @@ function MyPoketMessagePageContent() {
       if (response.message === "success" && response.data) {
         setMessages(response.data.letters);
         setUserName(response.data.nickname);
+        setIsOwner(response.data.is_owner);
       }
-    } catch (err) {
+    } catch {
       router.replace("/error?type=load");
     } finally {
       setIsLoading(false);
@@ -138,6 +140,8 @@ function MyPoketMessagePageContent() {
         onClose={() => setIsLetterModalOpen(false)}
         // letterIndex={selectedLetterIndex}
         letterId={messages[selectedLetterIndex]?.letter_id || null}
+        isOwner={isOwner}
+        userId={publicId!}
         onComplete={() => {
           // 편지 삭제 후 목록 새로고침
           fetchMessages();

--- a/app/my-tree/page.tsx
+++ b/app/my-tree/page.tsx
@@ -146,7 +146,7 @@ function MyTreePageContent() {
 
   // API에서 받은 데이터 사용
   const userName = treeData.nickname;
-  const isOwner = treeData.is_owner === "true";
+  const isOwner = treeData.is_owner;
   const letters = treeData.letters;
 
   /**
@@ -190,7 +190,7 @@ function MyTreePageContent() {
    */
   const handleLetterClick = (index: number) => {
     // 주인은 모든 편지를 볼 수 있고, 방문자는 오픈된 편지만 볼 수 있음
-    if (isOwner || letters[index].is_open === "true") {
+    if (isOwner === "true" || letters[index].is_open === "true") {
       setSelectedLetterIndex(index);
       setIsLetterModalOpen(true);
     }
@@ -210,7 +210,7 @@ function MyTreePageContent() {
       <div className="px-4 py-3 shrink-0 bg-[#BF0120] flex items-center justify-between gap-2">
         <span className="text-white text-xl font-bold whitespace-nowrap">{userName}{translate("tree.userTree")}</span>
         {/* is_owner에 따라 공유하기 버튼 표시*/}
-        {isOwner && (
+        {isOwner === "true" && (
           <button
             onClick={() => handleShareLinkClick()}
             className="relative w-36 h-10 flex items-center justify-center shrink-0"
@@ -241,7 +241,7 @@ function MyTreePageContent() {
       <div className="px-4 py-4 shrink-0 relative min-h-[200px]">
         {/* 도감 버튼과 십자 버튼 (메시지 버튼 포함) */}
         {/*is_owner에 따라 바텀컴포넌트 구분*/}
-        {isOwner ? (
+        {isOwner === "true" ? (
           <BottomButtons
             onUp={handleUp}
             onDown={handleDown}
@@ -274,6 +274,8 @@ function MyTreePageContent() {
         isModalOpen={isLetterModalOpen}
         onClose={() => setIsLetterModalOpen(false)}
         letterId={letters[selectedLetterIndex]?.letter_id || null}
+        isOwner={isOwner}
+        userId={publicId!}
         onComplete={() => {
           // 편지 삭제 후 트리 데이터 새로고침
           fetchTreeData();

--- a/app/my-tree/page.tsx
+++ b/app/my-tree/page.tsx
@@ -146,7 +146,7 @@ function MyTreePageContent() {
 
   // API에서 받은 데이터 사용
   const userName = treeData.nickname;
-  const isOwner = treeData.is_owner;
+  const isOwner = treeData.is_owner === "true";
   const letters = treeData.letters;
 
   /**
@@ -190,7 +190,7 @@ function MyTreePageContent() {
    */
   const handleLetterClick = (index: number) => {
     // 주인은 모든 편지를 볼 수 있고, 방문자는 오픈된 편지만 볼 수 있음
-    if (isOwner || letters[index].is_open) {
+    if (isOwner || letters[index].is_open === "true") {
       setSelectedLetterIndex(index);
       setIsLetterModalOpen(true);
     }

--- a/features/my-pokedex/components/PokedexGrid.tsx
+++ b/features/my-pokedex/components/PokedexGrid.tsx
@@ -2,14 +2,14 @@
 
 import { useRef, useEffect } from "react";
 import Image from "next/image";
-import { PokemonInDex } from "@/features/my-pokedex/usecases/getMyPokedex";
+import { POKEMON_DATA } from "@/features/shared/data/pokemonData";
 
 interface PokedexGridProps {
-  pokemons: PokemonInDex[];
+  ownedPokemonIds: number[]; // 보유한 포켓몬 ID 리스트
   selectedIndex: number;
 }
 
-export function PokedexGrid({ pokemons, selectedIndex }: PokedexGridProps) {
+export function PokedexGrid({ ownedPokemonIds, selectedIndex }: PokedexGridProps) {
   const selectedRef = useRef<HTMLDivElement>(null);
 
   // 선택된 항목으로 스크롤
@@ -35,10 +35,10 @@ export function PokedexGrid({ pokemons, selectedIndex }: PokedexGridProps) {
           alignContent: "start",
         }}
       >
-        {pokemons.map((pokemon, index) => {
+        {POKEMON_DATA.map((pokemon, index) => {
           const row = Math.floor(index / 4);
           const isNotFirstRow = row > 0;
-          const isOwned = pokemon.isOwned;
+          const isOwned = ownedPokemonIds.includes(pokemon.id);
 
           return (
             <div
@@ -47,7 +47,6 @@ export function PokedexGrid({ pokemons, selectedIndex }: PokedexGridProps) {
               style={{
                 aspectRatio: "5 / 6",
                 marginTop: isNotFirstRow ? "10px" : "0",
-
               }}
             >
               {/* 포켓몬 이미지 */}

--- a/features/my-pokedex/models/res/GetMyPokedexResponse.ts
+++ b/features/my-pokedex/models/res/GetMyPokedexResponse.ts
@@ -1,8 +1,10 @@
 import type { ApiResponse } from "@/features/shared/utils/api/apiClient";
 
-// 서버에서 받는 응답: 보유한 포켓몬 ID 리스트
+// 서버에서 받는 응답: 보유한 포켓몬 ID 리스트, 사용자 닉네임, 마스터 여부
 export interface GetMyPokedexData {
   pokemon_list: number[];
+  nickname: string;
+  isMaster: string;
 }
 
 export type GetMyPokedexResponse = ApiResponse<GetMyPokedexData>;

--- a/features/my-pokedex/repositories/pokedexRepository.ts
+++ b/features/my-pokedex/repositories/pokedexRepository.ts
@@ -3,9 +3,11 @@ import type { GetMyPokedexRequest } from "../models/req/GetMyPokedexRequest";
 import type { GetMyPokedexResponse } from "../models/res/GetMyPokedexResponse";
 
 // 보유한 포켓몬 ID 리스트 조회
-export async function getMyPokedexGet(req: GetMyPokedexRequest): Promise<GetMyPokedexResponse> {
+export async function getMyPokedexGet(
+    req: GetMyPokedexRequest
+): Promise<GetMyPokedexResponse> {
   return apiClient.get<GetMyPokedexResponse>(
     `/pokemon/get-my-pokemon?userId=${req.publicId}`,
-    true
+    true // 인증 필요
   );
 }

--- a/features/my-pokedex/usecases/getMyPokedex.ts
+++ b/features/my-pokedex/usecases/getMyPokedex.ts
@@ -1,27 +1,18 @@
 import { GetMyPokedexRequest } from "../models/req/GetMyPokedexRequest";
+import { GetMyPokedexResponse } from "../models/res/GetMyPokedexResponse";
 import { getMyPokedexGet } from "../repositories/pokedexRepository";
-import { PokemonInfo, POKEMON_DATA } from "@/features/shared/data/pokemonData";
 
-// 포켓몬 도감에서 표시할 포켓몬 (보유 여부 포함)
-export interface PokemonInDex extends PokemonInfo {
-  isOwned: boolean;
-}
-
+// API 응답 그대로 반환하는 usecase
 export async function getMyPokedex(
   req: GetMyPokedexRequest
-): Promise<PokemonInDex[]> {
+): Promise<GetMyPokedexResponse> {
   // validation
   if (!req.publicId) {
     throw new Error("publicId is required");
   }
 
-  // 1. 서버에서 보유한 포켓몬 ID 리스트 가져오기
-  const response = await getMyPokedexGet(req);
-  const ownedIdSet = new Set(response.data.pokemon_list);
+  // 서버에서 보유한 포켓몬 ID 리스트, 닉네임, 마스터 여부 가져오기
+  const res = await getMyPokedexGet(req);
 
-  // 2. 클라이언트 데이터와 합쳐서 도감 정보 생성
-  return POKEMON_DATA.map((pokemonInfo) => ({
-    ...pokemonInfo,
-    isOwned: ownedIdSet.has(pokemonInfo.id),
-  }));
+  return res;
 }

--- a/features/my-poket-message/components/MessageGrid.tsx
+++ b/features/my-poket-message/components/MessageGrid.tsx
@@ -58,7 +58,7 @@ export function MessageGrid({ messages, selectedIndex, onMessageClick }: Message
                 </div>
 
                 {/* 비공개 자물쇠 아이콘 */}
-                {!message.is_open && (
+                {message.is_open !== "true" && (
                   <div className="absolute top-1 right-1 w-[16px] h-[16px] flex items-center justify-center">
                     <Image src={LockIcon} alt="비공개" width={16} height={16} />
                   </div>

--- a/features/my-tree/components/Tree.tsx
+++ b/features/my-tree/components/Tree.tsx
@@ -115,9 +115,9 @@ export function Tree({
                 const letter = letters[actualMessageIndex];
 
                 // 열린 상태 확인: is_read로 몬스터볼 열림 여부 확인
-                const isRead = letter?.is_read;
+                const isRead = letter?.is_read === "true";
                 // 공개 여부 확인: is_open이 false면 자물쇠 표시
-                const isPublic = letter?.is_open;
+                const isPublic = letter?.is_open === "true";
 
                 return (
                   <div

--- a/features/my-tree/models/req/GetVisitorLetterRequest.ts
+++ b/features/my-tree/models/req/GetVisitorLetterRequest.ts
@@ -1,0 +1,4 @@
+export interface GetVisitorLetterRequest {
+  letter_id: string;
+  user_id: string;
+}

--- a/features/my-tree/models/req/OpenLetterRequest.ts
+++ b/features/my-tree/models/req/OpenLetterRequest.ts
@@ -1,4 +1,4 @@
 export interface OpenLetterRequest {
   letter_id: string;
-  is_open: boolean;
+  is_open: string;
 }

--- a/features/my-tree/models/res/GetLetterResponse.ts
+++ b/features/my-tree/models/res/GetLetterResponse.ts
@@ -3,7 +3,7 @@ import type { ApiResponse } from "@/features/shared/utils/api/apiClient";
 export interface LetterData {
   letter_id: string;
   sender_name: string;
-  is_opened: boolean;
+  is_open: boolean;
   letter_pokemon: number;
   content: string;
 }

--- a/features/my-tree/models/res/GetLetterResponse.ts
+++ b/features/my-tree/models/res/GetLetterResponse.ts
@@ -3,7 +3,7 @@ import type { ApiResponse } from "@/features/shared/utils/api/apiClient";
 export interface LetterData {
   letter_id: string;
   sender_name: string;
-  is_open: boolean;
+  is_open: string;
   letter_pokemon: number;
   content: string;
 }

--- a/features/my-tree/models/res/GetUserTreeResponse.ts
+++ b/features/my-tree/models/res/GetUserTreeResponse.ts
@@ -3,18 +3,17 @@ import type { ApiResponse } from "@/features/shared/utils/api/apiClient";
 export interface Letter {
   letter_id: string;
   sender_name: string;
-  is_open: boolean;
-  is_read?: boolean;
+  is_open: string;
+  is_read: string;
   letter_pokemon: number;
 }
 
 export interface UserTreeData {
   nickname: string;
-  is_owner: boolean;
-  is_master: boolean;
+  is_owner: string;
+  is_master: string;
   letters: Letter[];
   pokemon_list: number[];
 }
 
 export type GetUserTreeResponse = ApiResponse<UserTreeData>;
-

--- a/features/my-tree/repositories/letterRepository.ts
+++ b/features/my-tree/repositories/letterRepository.ts
@@ -3,13 +3,14 @@ import {
   type ApiResponse,
 } from "@/features/shared/utils/api/apiClient";
 import type { GetLetterRequest } from "../models/req/GetLetterRequest";
+import type { GetVisitorLetterRequest } from "../models/req/GetVisitorLetterRequest";
 import type { GetLetterResponse } from "../models/res/GetLetterResponse";
 import type { SendLetterRequest } from "../models/req/SendLetterRequest";
 import type { DeleteLetterRequest } from "../models/req/DeleteLetterRequest";
 import type { OpenLetterRequest } from "../models/req/OpenLetterRequest";
 
 /**
- * 편지의 상세 정보를 가져옵니다
+ * 편지의 상세 정보를 가져옵니다 (소유자용)
  * @param req - letter_id를 포함한 요청 데이터
  * @returns 편지 상세 정보 (발신자, 내용, 포켓몬 등)
  */
@@ -19,6 +20,20 @@ export async function getLetterById(
   return apiClient.get<GetLetterResponse>(
     `/letter/${req.letter_id}`,
     true // 인증 필요
+  );
+}
+
+/**
+ * 편지의 상세 정보를 가져옵니다 (방문자용)
+ * @param req - letter_id와 user_id를 포함한 요청 데이터
+ * @returns 편지 상세 정보 (발신자, 내용, 포켓몬 등)
+ */
+export async function getVisitorLetterById(
+  req: GetVisitorLetterRequest
+): Promise<GetLetterResponse> {
+  return apiClient.get<GetLetterResponse>(
+    `/letter/get-open-letter/${req.user_id}/${req.letter_id}`,
+    false // 인증 불필요
   );
 }
 

--- a/features/my-tree/usecases/getVisitorLetter.ts
+++ b/features/my-tree/usecases/getVisitorLetter.ts
@@ -1,0 +1,25 @@
+import { GetVisitorLetterRequest } from "../models/req/GetVisitorLetterRequest";
+import { GetLetterResponse } from "../models/res/GetLetterResponse";
+import { getVisitorLetterById } from "../repositories/letterRepository";
+
+/**
+ * 방문자가 편지의 상세 정보를 조회합니다
+ * @param req - letter_id와 user_id를 포함한 요청
+ * @returns 편지 상세 데이터 (발신자, 내용, 포켓몬 등)
+ */
+export async function getVisitorLetter(
+  req: GetVisitorLetterRequest
+): Promise<GetLetterResponse> {
+  // validation
+  if (!req.letter_id) {
+    throw new Error("Letter ID is required");
+  }
+  if (!req.user_id) {
+    throw new Error("User ID is required");
+  }
+
+  // API request
+  const res = await getVisitorLetterById(req);
+
+  return res;
+}

--- a/features/my-tree/usecases/openLetter.ts
+++ b/features/my-tree/usecases/openLetter.ts
@@ -15,7 +15,7 @@ export async function openLetter(
     throw new Error("편지 ID가 필요합니다.");
   }
 
-  if (typeof req.is_open !== "boolean") {
+  if (req.is_open !== "true" && req.is_open !== "false") {
     throw new Error("공개 여부 값이 필요합니다.");
   }
 

--- a/features/shared/components/Modal/LetterModal.tsx
+++ b/features/shared/components/Modal/LetterModal.tsx
@@ -5,6 +5,7 @@ import { useEffect, useState } from "react";
 import { useTranslation } from "@/features/shared/utils/translate/useLanguage";
 import { getPokemonImage } from "@/features/shared/data/pokemonData";
 import { getLetter } from "@/features/my-tree/usecases/getLetter";
+import { getVisitorLetter } from "@/features/my-tree/usecases/getVisitorLetter";
 import { deleteLetter } from "@/features/my-tree/usecases/deleteLetter";
 import { LetterData } from "@/features/my-tree/models/res/GetLetterResponse";
 import DeleteConfirmModal from "@/features/shared/components/Modal/DeleteConfirmModal";
@@ -24,6 +25,8 @@ interface LetterModalProps {
   isModalOpen: boolean;
   onClose: () => void;
   letterId: string | null;
+  isOwner: string;
+  userId: string;
   onComplete?: () => void;
 }
 
@@ -32,12 +35,16 @@ interface LetterModalProps {
  * @param isOpen - 모달 열림 여부
  * @param onClose - 모달 닫기 함수
  * @param letterId - 편지 ID
+ * @param isOwner - 트리 소유자 여부
+ * @param userId - 현재 트리의 소유자 ID
  * @param onComplete - 편지 삭제 또는 공개/비공개 상태 변경 후 페이지를 새로고침하기위한 callBack 함수
  */
 export default function LetterModal({
   isModalOpen,
   onClose,
   letterId,
+  isOwner,
+  userId,
   onComplete,
 }: LetterModalProps) {
   const { translate } = useTranslation();
@@ -56,7 +63,10 @@ export default function LetterModal({
         setIsLoading(true);
         setError(null);
 
-        const response = await getLetter({ letter_id: letterId });
+        // isOwner에 따라 다른 API 호출
+        const response = isOwner === "true"
+          ? await getLetter({ letter_id: letterId })
+          : await getVisitorLetter({ letter_id: letterId, user_id: userId });
 
         if (response.message === "success" && response.data) {
           setLetterData(response.data);
@@ -74,7 +84,7 @@ export default function LetterModal({
 
     fetchLetter();
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [isModalOpen, letterId]);
+  }, [isModalOpen, letterId, isOwner, userId]);
 
   // 편지 삭제 확인 모달 열기
   const handleDeleteClick = () => {
@@ -165,8 +175,8 @@ export default function LetterModal({
           />
         </button>
 
-        {/* 자물쇠 아이콘 (우상단) - is_open가 true일 때만 표시 */}
-        {letterData?.is_open !== "true" && (
+        {/* 자물쇠 아이콘 (우상단) - isOwner일 때만 표시, is_open가 false일 때 표시 */}
+        {isOwner === "true" && letterData?.is_open !== "true" && (
           <div className="absolute top-6 right-6">
             <Image
               src={LockIcon}
@@ -223,47 +233,49 @@ export default function LetterModal({
               </p>
             </div>
 
-            {/* 버튼 그룹 */}
-            <div className="flex justify-between items-center">
-              {/* 삭제 버튼 */}
-              <button
-                onClick={handleDeleteClick}
-                disabled={isDeleting}
-                className="w-20 h-12 bg-transparent border border-white text-white rounded-sm font-bold hover:bg-white hover:text-black transition-colors"
-              >
-                {isDeleting ? translate("letterModal.deleting") : translate("letterModal.delete")}
-              </button>
+            {/* 버튼 그룹 - isOwner일 때만 표시 */}
+            {isOwner === "true" && (
+              <div className="flex justify-between items-center">
+                {/* 삭제 버튼 */}
+                <button
+                  onClick={handleDeleteClick}
+                  disabled={isDeleting}
+                  className="w-20 h-12 bg-transparent border border-white text-white rounded-sm font-bold hover:bg-white hover:text-black transition-colors"
+                >
+                  {isDeleting ? translate("letterModal.deleting") : translate("letterModal.delete")}
+                </button>
 
-              {/* 메세지 공개/비공개 버튼 */}
-              <button
-                onClick={handlePublish}
-                disabled={isLoading}
-                className="relative h-12 flex items-center justify-center disabled:opacity-50 disabled:cursor-not-allowed"
-                style={{ width: '200px' }}
-              >
-                <Image
-                  src={letterData.is_open === "true" ? ButtonLetterUnpublic : ButtonLetterPublic}
-                  alt={letterData.is_open === "true" ? translate("letterModal.unpublish") : translate("letterModal.publish")}
-                  width={200}
-                  height={56}
-                  className="h-full w-auto object-contain"
-                />
-                <div className="absolute inset-0 flex items-center justify-center gap-2 pointer-events-none">
-                  {letterData.is_open === "true" && (
-                    <Image
-                      src={LockIcon}
-                      alt="자물쇠"
-                      width={16}
-                      height={16}
-                      className="object-contain"
-                    />
-                  )}
-                  <span className="text-black font-bold text-center text-base">
-                    {letterData.is_open === "true" ? translate("letterModal.unpublish") : translate("letterModal.publish")}
-                  </span>
-                </div>
-              </button>
-            </div>
+                {/* 메세지 공개/비공개 버튼 */}
+                <button
+                  onClick={handlePublish}
+                  disabled={isLoading}
+                  className="relative h-12 flex items-center justify-center disabled:opacity-50 disabled:cursor-not-allowed"
+                  style={{ width: '200px' }}
+                >
+                  <Image
+                    src={letterData.is_open === "true" ? ButtonLetterUnpublic : ButtonLetterPublic}
+                    alt={letterData.is_open === "true" ? translate("letterModal.unpublish") : translate("letterModal.publish")}
+                    width={200}
+                    height={56}
+                    className="h-full w-auto object-contain"
+                  />
+                  <div className="absolute inset-0 flex items-center justify-center gap-2 pointer-events-none">
+                    {letterData.is_open === "true" && (
+                      <Image
+                        src={LockIcon}
+                        alt="자물쇠"
+                        width={16}
+                        height={16}
+                        className="object-contain"
+                      />
+                    )}
+                    <span className="text-black font-bold text-center text-base">
+                      {letterData.is_open === "true" ? translate("letterModal.unpublish") : translate("letterModal.publish")}
+                    </span>
+                  </div>
+                </button>
+              </div>
+            )}
           </div>
         )}
       </div>

--- a/features/shared/components/Modal/LetterModal.tsx
+++ b/features/shared/components/Modal/LetterModal.tsx
@@ -115,14 +115,14 @@ export default function LetterModal({
 
       const response = await openLetter({
         letter_id: letterData.letter_id,
-        is_open: !letterData.is_opened,
+        is_open: !letterData.is_open,
       });
 
       if (response.message === "success") {
         // 모달 내 상태 즉시 업데이트
         setLetterData({
           ...letterData,
-          is_opened: !letterData.is_opened,
+          is_open: !letterData.is_open,
         });
 
         // 부모 컴포넌트 새로고침 (페이지 상태 업데이트)
@@ -166,7 +166,7 @@ export default function LetterModal({
         </button>
 
         {/* 자물쇠 아이콘 (우상단) - is_open가 true일 때만 표시 */}
-        {!letterData?.is_opened && (
+        {!letterData?.is_open && (
           <div className="absolute top-6 right-6">
             <Image
               src={LockIcon}
@@ -242,14 +242,14 @@ export default function LetterModal({
                 style={{ width: '200px' }}
               >
                 <Image
-                  src={letterData.is_opened ? ButtonLetterUnpublic : ButtonLetterPublic}
-                  alt={letterData.is_opened ? translate("letterModal.unpublish") : translate("letterModal.publish")}
+                  src={letterData.is_open ? ButtonLetterUnpublic : ButtonLetterPublic}
+                  alt={letterData.is_open ? translate("letterModal.unpublish") : translate("letterModal.publish")}
                   width={200}
                   height={56}
                   className="h-full w-auto object-contain"
                 />
                 <div className="absolute inset-0 flex items-center justify-center gap-2 pointer-events-none">
-                  {letterData.is_opened && (
+                  {letterData.is_open && (
                     <Image
                       src={LockIcon}
                       alt="자물쇠"
@@ -259,7 +259,7 @@ export default function LetterModal({
                     />
                   )}
                   <span className="text-black font-bold text-center text-base">
-                    {letterData.is_opened ? translate("letterModal.unpublish") : translate("letterModal.publish")}
+                    {letterData.is_open ? translate("letterModal.unpublish") : translate("letterModal.publish")}
                   </span>
                 </div>
               </button>

--- a/features/shared/components/Modal/LetterModal.tsx
+++ b/features/shared/components/Modal/LetterModal.tsx
@@ -115,14 +115,14 @@ export default function LetterModal({
 
       const response = await openLetter({
         letter_id: letterData.letter_id,
-        is_open: !letterData.is_open,
+        is_open: letterData.is_open === "true" ? "false" : "true",
       });
 
       if (response.message === "success") {
         // 모달 내 상태 즉시 업데이트
         setLetterData({
           ...letterData,
-          is_open: !letterData.is_open,
+          is_open: letterData.is_open === "true" ? "false" : "true",
         });
 
         // 부모 컴포넌트 새로고침 (페이지 상태 업데이트)
@@ -166,7 +166,7 @@ export default function LetterModal({
         </button>
 
         {/* 자물쇠 아이콘 (우상단) - is_open가 true일 때만 표시 */}
-        {!letterData?.is_open && (
+        {letterData?.is_open !== "true" && (
           <div className="absolute top-6 right-6">
             <Image
               src={LockIcon}
@@ -242,14 +242,14 @@ export default function LetterModal({
                 style={{ width: '200px' }}
               >
                 <Image
-                  src={letterData.is_open ? ButtonLetterUnpublic : ButtonLetterPublic}
-                  alt={letterData.is_open ? translate("letterModal.unpublish") : translate("letterModal.publish")}
+                  src={letterData.is_open === "true" ? ButtonLetterUnpublic : ButtonLetterPublic}
+                  alt={letterData.is_open === "true" ? translate("letterModal.unpublish") : translate("letterModal.publish")}
                   width={200}
                   height={56}
                   className="h-full w-auto object-contain"
                 />
                 <div className="absolute inset-0 flex items-center justify-center gap-2 pointer-events-none">
-                  {letterData.is_open && (
+                  {letterData.is_open === "true" && (
                     <Image
                       src={LockIcon}
                       alt="자물쇠"
@@ -259,7 +259,7 @@ export default function LetterModal({
                     />
                   )}
                   <span className="text-black font-bold text-center text-base">
-                    {letterData.is_open ? translate("letterModal.unpublish") : translate("letterModal.publish")}
+                    {letterData.is_open === "true" ? translate("letterModal.unpublish") : translate("letterModal.publish")}
                   </span>
                 </div>
               </button>

--- a/features/shared/utils/translate/useLanguage.tsx
+++ b/features/shared/utils/translate/useLanguage.tsx
@@ -51,19 +51,21 @@ export function getTranslation(language: Language, key: TranslationKey): string 
 
 // 브라우저 언어 감지 함수
 function detectBrowserLanguage(): Language {
-  if (typeof window === "undefined") return "ko";
+  if (typeof window === "undefined") return "en";
 
-  const browserLang = navigator.language.toLowerCase();
+  const browserLang = navigator.language?.toLowerCase();
 
+  if (!browserLang) return "en";
   if (browserLang.startsWith("ko")) return "ko";
   if (browserLang.startsWith("ja")) return "ja";
+  if (browserLang.startsWith("en")) return "en";
   return "en";
 }
 
 export function LanguageProvider({ children }: { children: ReactNode }) {
   const pathname = usePathname();
-  // 서버/클라이언트 초기값을 동일하게 "ko"로 설정하여 hydration 불일치 방지
-  const [language, setLanguageState] = useState<Language>("ko");
+  // 서버/클라이언트 초기값을 동일하게 "en"으로 설정하여 hydration 불일치 방지
+  const [language, setLanguageState] = useState<Language>("en");
   const [mounted, setMounted] = useState(false);
 
   // 클라이언트 마운트 확인 및 localStorage 동기화


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새 기능**
  * 방문자용 편지 조회 기능 추가
  * 소유권 기반 편지 접근 제어 구현
  * Pokédex 페이지에 사용자 닉네임 및 마스터 상태 표시

* **개선 사항**
  * 웹사이트 제목을 "PokémTree"에서 "PokéTree"로 변경
  * Pokédex 데이터가 API 기반으로 동적 로드됨
  * 기본 언어 설정을 영어로 변경

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->